### PR TITLE
mido: dex2oat: use 8 cores instead of 4 & Remove HAL3

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -43,6 +43,7 @@ bluetooth.hfp.client=1
 qcom.bluetooth.soc=smd
 
 # Camera
+persist.camera.HAL3.enabled=0
 persist.camera.isp.clock.optmz=0
 vidc.enc.dcvs.extra-buff-count=2
 media.camera.ts.monotonic=1
@@ -119,7 +120,7 @@ vidc.enc.disable.pq=true
 # Perf
 ro.vendor.extension_library=libqti-perfd-client.so
 ro.am.reschedule_service=true
-ro.sys.fw.dex2oat_thread_count=4
+ro.sys.fw.dex2oat_thread_count=8
 
 
 # Netmgrd


### PR DESCRIPTION
use more cores for faster app installation and remove hal3 for fix video calling issue